### PR TITLE
Fix copying bug.

### DIFF
--- a/src/components/TogglForm.tsx
+++ b/src/components/TogglForm.tsx
@@ -80,8 +80,16 @@ const TogglReply = ({ data }: TogglResponse) => {
                   );
                 })}
               </tr>
+              {rows}
             </tbody>
-            <tbody ref={tableRef}>{rows}</tbody>
+          </table>
+          {/*Hidden table without header for copying*/}
+          <table
+            aria-hidden="true"
+            ref={tableRef}
+            className="absolute w-0 h-0 -top-96 -left-96"
+          >
+            <tbody>{rows}</tbody>
           </table>
         </div>
         <button


### PR DESCRIPTION
Workaround so that copying works in both FireFox and Chrome without ruining layout. Using a hidden table without headers for copying, while displaying the table with the headers. At a later date could possibly try using a more modern API for copying instead of this hacky workaround.